### PR TITLE
Fix clients.md: Correctly wrap card rows on large screens

### DIFF
--- a/clients.md
+++ b/clients.md
@@ -66,6 +66,9 @@ link: /thinkathon/
         </div>
       </div>
     </div>
+
+    <div class='show-on-large clearfix'></div>
+
      <div class="col s12 m7 l4">
       <div class="card">
         <div class="card-logo row center-align">


### PR DESCRIPTION
**Warning: `jekyll build` required**

The card display on https://weareopen.coop/clients/ is not correct on certain large screen widths (such as 1920px). The cards end up a little displayed:

![screenshot_2018-10-13 client stories](https://user-images.githubusercontent.com/7606194/46911554-cff87280-cf1c-11e8-9168-a449b6b9b8cc.png)
 
This commit fixes this by adding a clearfix that is visible on large screen devices only between the first and second row of client cards:

![screenshot_2018-10-13 client stories 2](https://user-images.githubusercontent.com/7606194/46911566-1cdc4900-cf1d-11e8-9d58-3f6f723af407.png)


I can't get a correct build for this site using `jekyll build`. When I build it, pretty much every page in the /_site/ ends up as changed (something with the links having a different baseurl). So I decided not to build. Before or after merging, make sure to build!